### PR TITLE
Build Checks - Fixed Windows Build

### DIFF
--- a/.github/workflows/pull-requests_build-check.yml
+++ b/.github/workflows/pull-requests_build-check.yml
@@ -129,43 +129,29 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
-
-      - name: Install boost
-        uses: MarkusJx/install-boost@v2.1.0
-        id: install-boost
+      - name: MSYS2 Setup
+        uses: msys2/setup-msys2@v2
         with:
-          # REQUIRED: Specify the required boost version
-          # A list of supported versions can be found here:
-          # https://github.com/actions/boost-versions/blob/main/versions-manifest.json
-          boost_version: 1.78.0
-          # OPTIONAL: Specify a custom install location
-          boost_install_dir: 'C:'
-          # OPTIONAL: Specify a platform version
-          platform_version: 2019
-          toolset: mingw
-
-          # NOTE: If a boost version matching all requirements cannot be found,
-          # this build step will fail
-      - name: Setup Windows
-        run: |
-          C:\msys64\usr\bin\bash -lc "pacman --needed --noconfirm -S mingw-w64-x86_64-binutils mingw-w64-x86_64-openssl mingw-w64-x86_64-cmake mingw-w64-x86_64-toolchain mingw-w64-x86_64-opus mingw-w64-x86_64-x265 mingw-w64-x86_64-boost git yasm nasm diffutils make"
-#      - name: Build Windows
-#          env:
-#            BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
-#          run: |
-#            mkdir sunshine-windows-build && cd sunshine-windows-build
-#            set PATH=C:\msys64\mingw64\bin
-#            set BOOST_ROOT=C:\boost
-#            set BOOST_INCLUDEDIR=C:\boost
-#            set BOOST_LIBRARYDIR=C:\boost\lib
-#            cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=Release -DSUNSHINE_ASSETS_DIR=assets -G "MinGW Makefiles" ..
-#            mingw32-make -j2
+          update: true
+          install: >-
+            base-devel
+            git
+            mingw-w64-x86_64-binutils
+            mingw-w64-x86_64-openssl 
+            mingw-w64-x86_64-cmake
+            mingw-w64-x86_64-toolchain
+            mingw-w64-x86_64-opus 
+            mingw-w64-x86_64-x265
+            mingw-w64-x86_64-boost 
+            git 
+            yasm 
+            nasm 
+            diffutils 
+            make
       - name: Build Windows
-        env:
-          BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
+        shell: msys2 {0}
         run: |
           mkdir sunshine-windows-build && cd sunshine-windows-build
-          set PATH=C:\msys64\mingw64\bin
           cmake -DCMAKE_BUILD_TYPE=Release -DSUNSHINE_ASSETS_DIR=assets -G "Unix Makefiles" ..
           mingw32-make -j2
       - name: Package Windows

--- a/.github/workflows/pull-requests_build-check.yml
+++ b/.github/workflows/pull-requests_build-check.yml
@@ -152,7 +152,7 @@ jobs:
         shell: msys2 {0}
         run: |
           mkdir sunshine-windows-build && cd sunshine-windows-build
-          cmake -DCMAKE_BUILD_TYPE=Release -DSUNSHINE_ASSETS_DIR=assets -G "Unix Makefiles" ..
+          cmake -DCMAKE_BUILD_TYPE=Release -DSUNSHINE_ASSETS_DIR=assets -G "MinGW Makefiles" ..
           mingw32-make -j2
       - name: Package Windows
         run: |

--- a/sunshine/platform/windows/publish.cpp
+++ b/sunshine/platform/windows/publish.cpp
@@ -25,15 +25,18 @@ using namespace std::literals;
 #define SV(quote) __SV(quote)
 
 extern "C" {
+#ifndef __MINGW32__
 constexpr auto DNS_REQUEST_PENDING        = 9506L;
 constexpr auto DNS_QUERY_REQUEST_VERSION1 = 0x1;
 constexpr auto DNS_QUERY_RESULTS_VERSION1 = 0x1;
+#endif
 
 #define SERVICE_DOMAIN "local"
 
 constexpr auto SERVICE_INSTANCE_NAME = SV(SERVICE_NAME "." SERVICE_TYPE "." SERVICE_DOMAIN);
 constexpr auto SERVICE_TYPE_DOMAIN   = SV(SERVICE_TYPE "." SERVICE_DOMAIN);
 
+#ifndef __MINGW32__
 typedef struct _DNS_SERVICE_INSTANCE {
   LPWSTR pszInstanceName;
   LPWSTR pszHostName;
@@ -53,6 +56,7 @@ typedef struct _DNS_SERVICE_INSTANCE {
 
   DWORD dwInterfaceIndex;
 } DNS_SERVICE_INSTANCE, *PDNS_SERVICE_INSTANCE;
+#endif
 
 typedef VOID WINAPI DNS_SERVICE_REGISTER_COMPLETE(
   _In_ DWORD Status,
@@ -61,6 +65,7 @@ typedef VOID WINAPI DNS_SERVICE_REGISTER_COMPLETE(
 
 typedef DNS_SERVICE_REGISTER_COMPLETE *PDNS_SERVICE_REGISTER_COMPLETE;
 
+#ifndef __MINGW32__
 typedef struct _DNS_SERVICE_CANCEL {
   PVOID reserved;
 } DNS_SERVICE_CANCEL, *PDNS_SERVICE_CANCEL;
@@ -74,6 +79,7 @@ typedef struct _DNS_SERVICE_REGISTER_REQUEST {
   HANDLE hCredentials;
   BOOL unicastEnabled;
 } DNS_SERVICE_REGISTER_REQUEST, *PDNS_SERVICE_REGISTER_REQUEST;
+#endif
 
 _FN(_DnsServiceFreeInstance, VOID, (_In_ PDNS_SERVICE_INSTANCE pInstance));
 _FN(_DnsServiceDeRegister, DWORD, (_In_ PDNS_SERVICE_REGISTER_REQUEST pRequest, _Inout_opt_ PDNS_SERVICE_CANCEL pCancel));


### PR DESCRIPTION
## Description

By moving from msys64 to msys2 (used by AppVeyor and myself to build), and by applying https://github.com/loki-47-6F-64/sunshine/pull/296, now Sunshine builds correctly over GitHub actions on Windows. I don't see how to download the artifacts, so I cannot check if they actually work, but they should now compile fine

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the documentation blocks for new or existing components
